### PR TITLE
ci: create tag with specific token to trigger npmjs publish workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          token: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
 
       - name: setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0


### PR DESCRIPTION
If tag is created with repo's token, the creation of the tag does not trigger other wrokflows, to avoid infinite loops. Using another token is necessary