### PR TITLE
feat: add workspace management endpoints to OpenAPI spec

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -8,6 +8,7 @@ The `openapi.yaml` file describes the commands available in the Kortex CLI:
 
 - **Each path** in the specification corresponds to a CLI command
 - **Response formats** define the structure of the command output when using the `-o json` flag
+- **Input parameters** are not defined in the specification - only the output formats are documented
 
 ### Example
 
@@ -100,6 +101,6 @@ $ kortex-cli init -o json /tmp/not-found
 ```bash
 $ kortex-cli workspace remove unknown-id -o json
 {
-  "error": "Error: workspace not found: aze"
+  "error": "Error: workspace not found: unknown-id"
 }
 ```

--- a/cli/openapi.yaml
+++ b/cli/openapi.yaml
@@ -88,7 +88,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
               example:
-                error: "Error: workspace not found: aze"
+                error: "Error: workspace not found: unknown-id"
 components:
   schemas:
     Error:


### PR DESCRIPTION
Add /init, /init/verbose, and /remove endpoints to support programmatic workspace management from UIs. Include comprehensive scenario documentation in README demonstrating the complete workflow with JSON output examples and error handling.

Related to https://github.com/kortex-hub/kortex-cli/issues/54