### PR TITLE
feat(workspace): add mounts and environment in workspace configuration

### DIFF
--- a/workspace-configuration/openapi.yaml
+++ b/workspace-configuration/openapi.yaml
@@ -17,6 +17,42 @@ components:
   schemas:
     WorkspaceConfiguration:
       type: object
+      additionalProperties: false
+      properties:
+        mounts:
+          $ref: '#/components/schemas/Mounts'
+        environment:
+          type: array
+          items:
+            $ref: '#/components/schemas/EnvironmentVariable'
+
+    Mounts:
+      type: object
+      additionalProperties: false
+      properties:
+        dependencies:
+          type: array
+          items:
+            type: string
+          description: List of additional source directories to mount, with paths relative to the sources directory of the project (useful when working with git worktrees)
+        configs:
+          type: array
+          items:
+            type: string
+          description: List of home directories to mount, with paths relative to the HOME directory of the user
+
+    EnvironmentVariable:
+      type: object
+      additionalProperties: false
+      required:
+        - name
       properties:
         name:
           type: string
+          description: Name of the environment variable
+        value:
+          type: string
+          description: Value of the environment variable (mutually exclusive with secret)
+        secret:
+          type: string
+          description: Name of the secret containing the value (mutually exclusive with value)


### PR DESCRIPTION
fixes #14 

The value/secret fields in the EnvironmentVariable are marked as mutually exclusive, but this is not enforced by the spec (using oneOf). This is due to the generator not providing a convenient implementation for this. The responsability of enforcing this rule will be let to the user