### PR TITLE
feat(workspace): add flexible mount configuration (#18)

### DIFF
--- a/workspace-configuration/openapi.yaml
+++ b/workspace-configuration/openapi.yaml
@@ -61,6 +61,7 @@ components:
           description: Path in the workspace filesystem where the host path will be mounted. Can use $SOURCES or $HOME variables.
         ro:
           type: boolean
+          default: false
           description: Mount as read-only. Defaults to false (read-write).
 
     EnvironmentVariable:


### PR DESCRIPTION
Replace the separate dependencies and configs arrays with a unified mounts array that supports absolute paths, variable substitution ($SOURCES, $HOME), custom mount targets, and read-only mounts.

Fixes #18 