### PR TITLE
feat(cli): add optional model field to Workspace schema

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -53,6 +53,7 @@ $ kortex-cli init --agent claude -v -o json
   "name": "workspace1",
   "project": "https://github.com/user/repo/",
   "agent": "claude",
+  "model": "model1",
   "paths": {
     "source": "/home/user/workspace1",
     "configuration": "/home/user/workspace1/.kortex"
@@ -69,6 +70,7 @@ $ kortex-cli init --agent claude --project my-project -v -o json
   "name": "workspace1",
   "project": "my-project",
   "agent": "claude",
+  "model": "model1",
   "paths": {
     "source": "/home/user/workspace1",
     "configuration": "/home/user/workspace1/.kortex"
@@ -87,6 +89,7 @@ $ kortex-cli workspace list -o json
       "name": "workspace1",
       "project": "https://github.com/user/repo/",
       "agent": "claude",
+      "model": "model1",
       "paths": {
         "source": "/home/user/workspace1",
         "configuration": "/home/user/workspace1/.kortex"

--- a/cli/openapi.yaml
+++ b/cli/openapi.yaml
@@ -38,6 +38,7 @@ paths:
                 name: workspace1
                 project: project1
                 agent: claude
+                model: model1
                 state: stopped
                 paths:
                   source: /home/user/workspace1
@@ -66,6 +67,7 @@ paths:
                     name: workspace1
                     project: project1
                     agent: claude
+                    model: model1
                     state: running
                     paths:
                       source: /home/user/workspace1
@@ -210,6 +212,8 @@ components:
         project:
           type: string
         agent:
+          type: string
+        model:
           type: string
         state:
           $ref: '#/components/schemas/WorkspaceState'


### PR DESCRIPTION
Add an optional model field to the Workspace schema to allow specifying which model is used for the workspace agent.

Closes #25