### PR TITLE
feat(cli): add secret create, list, and remove commands

### DIFF
--- a/cli/openapi.yaml
+++ b/cli/openapi.yaml
@@ -199,7 +199,19 @@ paths:
                 items:
                   - name: my-secret
                     type: github
-                    description: ""
+                    description: "GitHub token"
+                  - name: my-other-secret
+                    type: other
+                    description: "a secret for example.com API"
+                    envs:
+                      - EXAMPLE_API_KEY
+                      - EX_API_KEY
+                    hosts:
+                      - api.example.com
+                      - dev.example.com
+                    path: /
+                    header: Authorization
+                    headerTemplate: "Bearer ${value}"
         '400':
           description: Error response
           content:
@@ -334,6 +346,20 @@ components:
         type:
           type: string
         description:
+          type: string
+        envs:
+          type: array
+          items:
+            type: string
+        hosts:
+          type: array
+          items:
+            type: string
+        path:
+          type: string
+        header:
+          type: string
+        headerTemplate:
           type: string
       required:
       - name

--- a/cli/openapi.yaml
+++ b/cli/openapi.yaml
@@ -165,6 +165,69 @@ paths:
                 $ref: '#/components/schemas/Error'
               example:
                 error: "Error: workspace not found: unknown-id"
+  /secret/create:
+    get:
+      summary: Create a secret
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecretName'
+              example:
+                name: my-secret
+        '400':
+          description: Error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error: "Error: secret already exists: my-secret"
+  /secret/list:
+    get:
+      summary: List secrets
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecretsList'
+              example:
+                items:
+                  - name: my-secret
+                    type: github
+                    description: ""
+        '400':
+          description: Error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error: "Error: failed to list secrets"
+  /secret/remove:
+    get:
+      summary: Remove a secret
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecretName'
+              example:
+                name: my-secret
+        '400':
+          description: Error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error: "Error: secret not found: my-secret"
 components:
   schemas:
     Error:
@@ -252,5 +315,37 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Workspace'
+      required:
+      - items
+    SecretName:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+      required:
+      - name
+    SecretInfo:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+        description:
+          type: string
+      required:
+      - name
+      - type
+      - description
+    SecretsList:
+      type: object
+      additionalProperties: false
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/SecretInfo'
       required:
       - items


### PR DESCRIPTION
Documents the JSON output schemas for secret management CLI commands:

- `kdn secret create my-secret ... -o json` -> `{ "name": "my-secret" }`
- `kdn secret list -o json` -> 
```
{ "items": [ 
  { 
    "name": "my-secret",
    "type": "other",
    "description": "",
    "hosts": [           // optional
      "api.example.com",
      "dev.example.com"
    ],
    "path": "/",            // optional
    "header": "Auth",           // optional
    "headerTemplate": "Bearer ..."           // optional
  }
]}
```
- `kdn secret remove my-secret -o json` -> `{ "name": "my-secret" }`

Closes #48