### PR TITLE
feat(cli): add description to service list output

### DIFF
--- a/cli/openapi.yaml
+++ b/cli/openapi.yaml
@@ -253,6 +253,7 @@ paths:
               example:
                 items:
                   - name: github
+                    description: "GitHub API"
                     hostPattern: "api.github.com"
                     headerName: "Authorization"
                     headerTemplate: "Bearer ${value}"
@@ -406,6 +407,8 @@ components:
       additionalProperties: false
       properties:
         name:
+          type: string
+        description:
           type: string
         hostPattern:
           type: string


### PR DESCRIPTION
Adds an optional `description` field to the `SecretService` schema so that service descriptions are included in `kdn service list` output.

Closes #56