### PR TITLE
feat(workspace): add ports field to WorkspaceConfiguration

### DIFF
--- a/workspace-configuration/openapi.yaml
+++ b/workspace-configuration/openapi.yaml
@@ -50,6 +50,9 @@ paths:
                   hosts:
                     - "api.example.com"
                     - "registry.npmjs.org"
+                ports:
+                  - 8080
+                  - 5432
                 secrets:
                   - "my-github-secret"
                   - "my-other-secret"
@@ -81,6 +84,14 @@ components:
           $ref: '#/components/schemas/McpConfiguration'
         network:
           $ref: '#/components/schemas/NetworkConfiguration'
+        ports:
+          type: array
+          uniqueItems: true
+          items:
+            type: integer
+            minimum: 1
+            maximum: 65535
+          description: List of TCP ports to expose from the workspace.
         secrets:
           type: array
           items:


### PR DESCRIPTION
Allows users to specify a list of TCP port numbers to expose from the workspace, alongside the existing network and environment configuration.

Related to https://github.com/openkaiden/kdn/issues/385