### PR TITLE
feat(rust): add Cargo workspace and Rust type generation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Install cargo-typify
-        run: cargo install cargo-typify
+        run: cargo install --version 0.6.2 cargo-typify
 
       - name: Generate tag utilities
         id: TAG_UTIL

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,13 @@ jobs:
       - name: setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version-file: 'cli/go/go.mod'          
+          go-version-file: 'cli/go/go.mod'
+
+      - name: setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Install cargo-typify
+        run: cargo install cargo-typify
 
       - name: Generate tag utilities
         id: TAG_UTIL
@@ -76,6 +82,18 @@ jobs:
 
           # add generated file for workspace configuration
           git add workspace-configuration/go/workspace.go
+
+          # Generate the Rust types for kdn
+          (cd cli/rust && make gen)
+
+          # add generated file for kdn
+          git add cli/rust/src/lib.rs
+
+          # Generate the Rust types for workspace configuration
+          (cd workspace-configuration/rust && make gen)
+
+          # add generated file for workspace configuration
+          git add workspace-configuration/rust/src/lib.rs
 
           # commit the changes
           git commit -m "chore: 🥁 tagging ${{ steps.TAG_UTIL.outputs.githubTag }} 🥳"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/Cargo.lock
+/target/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,22 @@
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+[workspace]
+members = [
+    "cli/rust",
+    "workspace-configuration/rust",
+]
+resolver = "2"

--- a/cli/rust/Cargo.toml
+++ b/cli/rust/Cargo.toml
@@ -1,0 +1,27 @@
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "kdn-api"
+version = "0.0.1"
+edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/openkaiden/kdn-api"
+description = "Rust types for the Kaiden CLI API"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/cli/rust/Makefile
+++ b/cli/rust/Makefile
@@ -1,0 +1,29 @@
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+.PHONY: clean gen all
+
+all: gen
+
+gen: clean
+	mkdir -p src
+	yq -o json '{"$$schema": "http://json-schema.org/draft-07/schema#", "definitions": .components.schemas}' \
+		../openapi.yaml | sed 's|#/components/schemas/|#/definitions/|g' > /tmp/gen-schema.yaml
+	cargo typify /tmp/gen-schema.yaml --output src/lib.rs
+	rm /tmp/gen-schema.yaml
+
+clean:
+	rm -f src/lib.rs

--- a/cli/rust/Makefile
+++ b/cli/rust/Makefile
@@ -20,10 +20,10 @@ all: gen
 
 gen: clean
 	mkdir -p src
+	$(eval SCHEMA_TMP := $(shell mktemp "$${TMPDIR:-/tmp}/gen-schema.XXXXXX"))
 	yq -o json '{"$$schema": "http://json-schema.org/draft-07/schema#", "definitions": .components.schemas}' \
-		../openapi.yaml | sed 's|#/components/schemas/|#/definitions/|g' > /tmp/gen-schema.yaml
-	cargo typify /tmp/gen-schema.yaml --output src/lib.rs
-	rm /tmp/gen-schema.yaml
+		../openapi.yaml | sed 's|#/components/schemas/|#/definitions/|g' > $(SCHEMA_TMP)
+	cargo typify $(SCHEMA_TMP) --output src/lib.rs; rm -f $(SCHEMA_TMP)
 
 clean:
 	rm -f src/lib.rs

--- a/workspace-configuration/rust/Cargo.toml
+++ b/workspace-configuration/rust/Cargo.toml
@@ -1,0 +1,27 @@
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "kdn-workspace-configuration"
+version = "0.0.1"
+edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/openkaiden/kdn-api"
+description = "Rust types for the Kaiden Workspace Configuration"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/workspace-configuration/rust/Makefile
+++ b/workspace-configuration/rust/Makefile
@@ -1,0 +1,29 @@
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+.PHONY: clean gen all
+
+all: gen
+
+gen: clean
+	mkdir -p src
+	yq -o json '{"$$schema": "http://json-schema.org/draft-07/schema#", "definitions": .components.schemas}' \
+		../openapi.yaml | sed 's|#/components/schemas/|#/definitions/|g' > /tmp/gen-schema.yaml
+	cargo typify /tmp/gen-schema.yaml --output src/lib.rs
+	rm /tmp/gen-schema.yaml
+
+clean:
+	rm -f src/lib.rs

--- a/workspace-configuration/rust/Makefile
+++ b/workspace-configuration/rust/Makefile
@@ -20,10 +20,10 @@ all: gen
 
 gen: clean
 	mkdir -p src
+	$(eval SCHEMA_TMP := $(shell mktemp "$${TMPDIR:-/tmp}/gen-schema.XXXXXX"))
 	yq -o json '{"$$schema": "http://json-schema.org/draft-07/schema#", "definitions": .components.schemas}' \
-		../openapi.yaml | sed 's|#/components/schemas/|#/definitions/|g' > /tmp/gen-schema.yaml
-	cargo typify /tmp/gen-schema.yaml --output src/lib.rs
-	rm /tmp/gen-schema.yaml
+		../openapi.yaml | sed 's|#/components/schemas/|#/definitions/|g' > $(SCHEMA_TMP)
+	cargo typify $(SCHEMA_TMP) --output src/lib.rs; rm -f $(SCHEMA_TMP)
 
 clean:
 	rm -f src/lib.rs


### PR DESCRIPTION
Add a root Cargo workspace and two new crates (kdn-api, kdn-workspace-configuration) that generate serde-annotated Rust types from the OpenAPI specs using cargo-typify. The release workflow is extended to install the Rust toolchain and run make gen for both crates, committing the generated src/lib.rs files alongside the existing Go artifacts.

- Tested in https://github.com/feloy/kdn-api/pull/1 that the generated code is usable from another project
- GH Workflow to be confirmed