### PR TITLE
feat(workspace-config): add description field to WorkspaceConfiguration

### DIFF
--- a/workspace-configuration/openapi.yaml
+++ b/workspace-configuration/openapi.yaml
@@ -14,6 +14,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/WorkspaceConfiguration'
               example:
+                description: "Backend service workspace with Node.js and database access"
                 mounts:
                   - host: "$SOURCES/../main"
                     target: "$SOURCES/../main"
@@ -66,6 +67,10 @@ components:
       type: object
       additionalProperties: false
       properties:
+        description:
+          type: string
+          maxLength: 500
+          description: Human-readable description of the workspace.
         mounts:
           type: array
           items:


### PR DESCRIPTION
Add an optional description property (string, max 500 chars) to the
WorkspaceConfiguration schema. This allows workspace creators to attach
a human-readable description that persists in workspace.json.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Required by https://github.com/openkaiden/kaiden/issues/2383